### PR TITLE
Split ItemBlocks to workaround classloading issue

### DIFF
--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/BlockBase.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/BlockBase.java
@@ -18,6 +18,6 @@ public class BlockBase extends Block
 		setCreativeTab(CaliberDrinksMod.tabCaliberDrinksMod);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 }

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/BlockFluid.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/BlockFluid.java
@@ -17,6 +17,6 @@ public class BlockFluid extends BlockFluidClassic
 		setRegistryName(name);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 }

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockCoconutPlant.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockCoconutPlant.java
@@ -25,7 +25,7 @@ public class BlockCoconutPlant extends BlockCrops
 		setRegistryName(name);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 	
 	@Override

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockCoffeeBeanPlant.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockCoffeeBeanPlant.java
@@ -25,7 +25,7 @@ public class BlockCoffeeBeanPlant extends BlockCrops
 		setRegistryName(name);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 	
 	@Override

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockCranberryPlant.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockCranberryPlant.java
@@ -25,7 +25,7 @@ public class BlockCranberryPlant extends BlockCrops
 		setRegistryName(name);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 	
 	@Override

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockGrapePlant.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockGrapePlant.java
@@ -25,7 +25,7 @@ public class BlockGrapePlant extends BlockCrops
 		setRegistryName(name);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 	
 	@Override

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockGrapefruitPlant.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockGrapefruitPlant.java
@@ -25,7 +25,7 @@ public class BlockGrapefruitPlant extends BlockCrops
 		setRegistryName(name);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 	
 	@Override

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockLemonPlant.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockLemonPlant.java
@@ -25,7 +25,7 @@ public class BlockLemonPlant extends BlockCrops
 		setRegistryName(name);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 	
 	@Override

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockMangoPlant.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockMangoPlant.java
@@ -25,7 +25,7 @@ public class BlockMangoPlant extends BlockCrops
 		setRegistryName(name);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 	
 	@Override

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockOrangePlant.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockOrangePlant.java
@@ -24,7 +24,7 @@ public class BlockOrangePlant extends BlockCrops
 		setRegistryName(name);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 	
 	@Override

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockPeachPlant.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockPeachPlant.java
@@ -25,7 +25,7 @@ public class BlockPeachPlant extends BlockCrops
 		setRegistryName(name);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 	
 	@Override

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockPineapplePlant.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockPineapplePlant.java
@@ -25,7 +25,7 @@ public class BlockPineapplePlant extends BlockCrops
 		setRegistryName(name);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 	
 	@Override

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockPomegranatePlant.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockPomegranatePlant.java
@@ -25,7 +25,7 @@ public class BlockPomegranatePlant extends BlockCrops
 		setRegistryName(name);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 	
 	@Override

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockStrawberryPlant.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockStrawberryPlant.java
@@ -25,7 +25,7 @@ public class BlockStrawberryPlant extends BlockCrops
 		setRegistryName(name);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 	
 	@Override

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockTeaLeafPlant.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockTeaLeafPlant.java
@@ -25,7 +25,7 @@ public class BlockTeaLeafPlant extends BlockCrops
 		setRegistryName(name);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 	
 	@Override

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockTomatoPlant.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockTomatoPlant.java
@@ -25,7 +25,7 @@ public class BlockTomatoPlant extends BlockCrops
 		setRegistryName(name);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 	
 	@Override

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockWhiteGrapePlant.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/blocks/plants/BlockWhiteGrapePlant.java
@@ -25,7 +25,7 @@ public class BlockWhiteGrapePlant extends BlockCrops
 		setRegistryName(name);
 		
 		ModBlocks.BLOCKS.add(this);
-		ModItems.ITEMS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
+		ModBlocks.ITEMBLOCKS.add(new ItemBlock(this).setRegistryName(this.getRegistryName()));
 	}
 	
 	@Override

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/init/ModBlocks.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/init/ModBlocks.java
@@ -37,11 +37,14 @@ import com.luisxcaliber.caliberdrinksmod.blocks.plants.BlockWhiteGrapePlant;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
 
 public class ModBlocks 
 {
-	public static final List<Block> BLOCKS = new ArrayList<Block>();
-	
+	public static final List<Block> BLOCKS = new ArrayList<>();
+	public static final List<Item> ITEMBLOCKS = new ArrayList<>();
+
 	//Bushes
 	public static final Block GRAPE_BUSH = new BlockGrapeBush("grape_bush", Material.LEAVES);
 	public static final Block ORANGE_BUSH = new BlockOrangeBush("orange_bush", Material.LEAVES);

--- a/src/main/java/com/luisxcaliber/caliberdrinksmod/util/handlers/RegistryHandler.java
+++ b/src/main/java/com/luisxcaliber/caliberdrinksmod/util/handlers/RegistryHandler.java
@@ -22,6 +22,7 @@ public class RegistryHandler
 	public static void onItemRegister(RegistryEvent.Register<Item> event)
 	{
 		event.getRegistry().registerAll(ModItems.ITEMS.toArray(new Item[0]));
+		event.getRegistry().registerAll(ModBlocks.ITEMBLOCKS.toArray(new Item[0]));
 	}
 	
 	@SubscribeEvent


### PR DESCRIPTION
Basically you had some circularity issues in your classloading.
Here's my comment from Discord for more details on why this happens : 
> Basically, at some point blocks registering happens.
This causes class loading of his ModBlocks, which includes instantiating his BlockBases. In BlockBase ctor, he adds stuff to ModItems.ITEMS which in turn causes ModItems classloading and therefore all the item instantiations.
One of these items (the bucket) looks for ModBlocks.APPLE_JUICE_BLOCK which is still null as ModBlocks hasn't finished it's clinit

This is an ugly workaround to an ugly issue (you shouldn't really be static initialising everything like this) but it's probably the easiest fix.